### PR TITLE
d actual edits to first para

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <p align="center">
     <h1>MapReader</h1>
     </p>
-    <h2>A computer vision pipeline for analyzing and exploring images and maps at scale</h2>
+    <h2>A computer vision pipeline for analyzing and exploring maps and images at scale</h2>
 </div>
  
 <p align="center">
@@ -30,9 +30,9 @@
 
 # What is MapReader?
 
-MapReader is an end-to-end computer vision (CV) pipeline for analyzing and exploring large collections of images and maps. 
+MapReader is an end-to-end computer vision (CV) pipeline for analyzing and exploring large collections of maps and images. 
 
-MapReader was originally developed in the [Living with Machines](https://livingwithmachines.ac.uk/) project to analyze large historical maps (hence the name). However, MapReader is a _**generalisable**_ computer vision pipeline applicable in both <ins>non-map images</ins> and <ins>maps</ins> and in a wide variety of domains. See [Gallery](#gallery) for some examples.
+MapReader was developed in the [Living with Machines](https://livingwithmachines.ac.uk/) project to analyze large collections of historical maps but is a _**generalisable**_ computer vision pipeline which can be applied to _**any images**_ in a wide variety of domains. See [Gallery](#gallery) for some examples.
 
 Refer to each tutorial/example in the [use cases](#use-cases) section for more details on MapReader's relevant functionalities for <ins>non-map</ins> and <ins>map</ins> images and how MapReader can help to analyze large image datasets.
 


### PR DESCRIPTION
I've restored the order to 'maps' -> 'images' so we get a clearer narative as in the current existing repo; and shortened / combined a sentence, as it was repeating 'non-maps' and 'maps', so I used 'any images' instead to make it more intuitive to read.

I was also going to add a few sentences giving the nice positive spin about interdisciplinary cross-pollination of image analysis, but not sure where this should go: I don't want to break the flow to the instructions, so perhaps it can go after the bullet points?