### PR TITLE
Enable manual trigger on GH Action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,9 +2,11 @@
 name: Publish Tagged Python 🐍 distributions 📦 to PyPI
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - v*
+
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
### Summary

The "Publish Tagged Python 🐍 distributions 📦 to PyPI" action is not triggering when expected.
This adds a manuual trigger to that workflow, for debug purposes.
  
- [ ] Self-review code
- [ ] Ensure submission passes current tests
- [ ] Add tests
  
### Reviewer checklist
  
Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
