### PR TITLE
Add error if image file is broken/truncated.

### DIFF
--- a/mapreader/load/images.py
+++ b/mapreader/load/images.py
@@ -635,10 +635,13 @@ See https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes for mor
         """
         tree_level = self._get_tree_level(image_id)
 
-        myimg = mpimg.imread(self.images[tree_level][image_id]["image_path"])
-        # shape = (hwc)
-        myimg_shape = myimg.shape
-        self.images[tree_level][image_id]["shape"] = myimg_shape
+        try: 
+            myimg = mpimg.imread(self.images[tree_level][image_id]["image_path"])
+            # shape = (hwc)
+            myimg_shape = myimg.shape
+            self.images[tree_level][image_id]["shape"] = myimg_shape
+        except OSError:
+            raise ValueError(f'[ERROR] Problem with "{image_id}". Please either redownload or remove from list of images to load.')
 
     def _add_coord_increments_id(
         self, image_id: Union[int, str], verbose: Optional[bool] = False


### PR DESCRIPTION
### Summary

Currently, if you stop a download halfway you can end up with partially created map images  which cannot be read by matplot.image.

This PR adds an error message if this is the case, and tells the user to go back and redownload that map image.

Fixes #204 

### Checklist before assigning a reviewer (update as needed)
  
- [ ] Self-review code
- [ ] Ensure submission passes current tests
- [ ] Add tests
  
### Reviewer checklist
  
Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
