### PR TITLE
Only deploy to conda-forge on tagged commits or when manually triggered

### DIFF
--- a/.github/workflows/publish-to-conda-forge.yml
+++ b/.github/workflows/publish-to-conda-forge.yml
@@ -2,10 +2,11 @@
 name: Publish to Conda Forge
 
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - main
-
+    tags:
+      - v*
+      
 jobs:
 
   build_conda:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ conda_debug/
 docs/build/
 docs/source/api/mapreader/
 dist/
+.coverage
+.coverage.*


### PR DESCRIPTION
### Summary

This PR fixes (or contributes to fixing) https://github.com/Living-with-machines/MapReader/issues/162

It seems that this error was caused by the relevant conda-forage account using more than its allocated storage space.

### Describe your changes

This PR alters the deployment action to only publish to conda-forge on tagged commits (or when manually triggered). This is the same behaviour as for PyPI.

Additionally, old versions of MapReader have been manually deleted from conda-forge.

### Checklist before assigning a reviewer (update as needed)
  
- [x] Self-review code
- [ ] Ensure submission passes current tests
- [x] Add tests
  
### Reviewer checklist
  
Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
