### PR TITLE
split Code of conduct

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,0 +1,23 @@
+# MapReader Project Members
+
+This document provides details about the project members and contributors working (or having previously worked) on _MapReader_ in a paid capacity, organizational agreement, in-kind contributions or grant proposal-based collaboration.
+It further outlines expectations and responsibilities with regard to working on the project.
+
+## Current Project Members
+
+| Name | Affiliation | Community Role | Start date | Previous roles |
+|---|---|---|---|---|
+| Katherine McDonough<br>([@kmcdono2](https://github.com/kmcdono2)) | The Alan Turing Institute & Lancaster University| ? | 2019 - Present | - |
+| Daniel Wilson<br>([@dcsw2](https://github.com/dcsw2)) | The Alan Turing Institute | Historian/Researcher | 2019 - Present | - |
+| Andy Smith<br>([@andrewphilipsmith](https://github.com/andrewphilipsmith)) | The Alan Turing Institute | Research Data Scientist | Jan 2022 - Present | - |
+| Kalle Westerling<br>([@kallewesterling](https://github.com/kallewesterling)) | British Library | Research Software Engineer | Jan 2022 - Present | - |
+| Rosie Wood<br>([@rwood-97](https://github.com/rwood-97)) | The Alan Turing Institute | Research Data Scientist | Jan 2023 - Present | - |
+
+## Previous Project Members
+
+The following people are no longer paid to work on the project (although they remain very valuable members of the community!)
+You can request contact information through the project members above, or tag them in the GitHub issues and Pull Requests so others can answer if the folks you're looking for are not around.
+
+| Name | Affiliation | Community Role | Dates |
+|---|---|---|---|
+| Kasra Hosseini<br>([@kasra-hosseini](https://github.com/kasra-hosseini)) | Formerly The Alan Turing Institute | Research Data Scientist | 2019 - 2022 |

--- a/docs/source/Coc.rst
+++ b/docs/source/Coc.rst
@@ -1,0 +1,15 @@
+Code of Conduct and Inclusivity
+================================
+
+We are currently in the process of developing a Code of Conduct. 
+In the meantime, we look to the `Code of Conduct <https://github.com/alan-turing-institute/the-turing-way/blob/main/CODE_OF_CONDUCT.md>`_ from The Turing Way as a model.
+
+We aim to be inclusive of people from all walks of life and all research fields. 
+These intentions must be reflected in the contributions that we make.
+
+We therefore encourage intentional, inclusive actions from contributors to MapReader. 
+Here are a few examples of such actions:
+
+- Use respectful, gender-neutral and inclusive language.
+- Aim to include perspectives of researchers from different research backgrounds such as science, humanities and social sciences by not limiting the scope to only scientific domains.
+- Make sure that color palettes used throughout figures are accessible to color-blind readers and contributors.

--- a/docs/source/Contribution-guide/Contribution-guide.rst
+++ b/docs/source/Contribution-guide/Contribution-guide.rst
@@ -23,22 +23,6 @@ You can also get in touch with the MapReader team personally by:
 - Tagging us on Github (find our Github handles `here <https://github.com/Living-with-machines/MapReader/blob/main/ways_of_working.md>`__).
 - Messaging us on Slack.
 - Emailing Katie McDonough at k.mcdonough@lancaster.ac.uk.
-  
-Code of Conduct and inclusivity
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-We are currently in the process of developing a Code of Conduct. 
-In the meantime, we look to the `Code of Conduct <https://github.com/alan-turing-institute/the-turing-way/blob/main/CODE_OF_CONDUCT.md>`_ from The Turing Way as a model.
-
-We aim to be inclusive of people from all walks of life and all research fields. 
-These intentions must be reflected in the contributions that we make.
-
-We therefore encourage intentional, inclusive actions from contributors to MapReader. 
-Here are a few examples of such actions:
-
-- Use respectful, gender-neutral and inclusive language (learn more about inclusive writing on page 22 of University of Leicester Study Skills pdf, also available as a zipped html).
-- Aim to include perspectives of researchers from different research backgrounds such as science, humanities and social sciences by not limiting the scope to only scientific domains.
-- Make sure that color palettes used throughout figures are accessible to color-blind readers and contributors.
 
 Pre-requisites
 --------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,8 @@ MapReader
 **A computer vision pipeline for exploring and analyzing images at scale** 
 
 .. toctree::
-   :maxdepth: 1
+   :hidden:
+   :maxdepth: 2
 
    About
    Events
@@ -20,6 +21,7 @@ MapReader
    User-guide/User-guide
    Worked-examples/Worked-examples
    api/index
+   Coc
    Contribution-guide/Contribution-guide
    Developers-guide
 

--- a/ways_of_working.md
+++ b/ways_of_working.md
@@ -1,26 +1,4 @@
-# MapReader Project Members
-
-This document provides details about the project members and contributors working (or having previously worked) on _MapReader_ in a paid capacity, organizational agreement, in-kind contributions or grant proposal-based collaboration.
-It further outlines expectations and responsibilities with regard to working on the project.
-
-## Current Project Members
-
-| Name | Affiliation | Community Role | Start date | Previous roles |
-|---|---|---|---|---|
-| Katherine McDonough<br>([@kmcdono2](https://github.com/kmcdono2)) | The Alan Turing Institute & Lancaster University| ? | 2019 - Present | - |
-| Daniel Wilson<br>([@dcsw2](https://github.com/dcsw2)) | The Alan Turing Institute | Historian/Researcher | 2019 - Present | - |
-| Andy Smith<br>([@andrewphilipsmith](https://github.com/andrewphilipsmith)) | The Alan Turing Institute | Research Data Scientist | Jan 2022 - Present | - |
-| Kalle Westerling<br>([@kallewesterling](https://github.com/kallewesterling)) | British Library | Research Software Engineer | Jan 2022 - Present | - |
-| Rosie Wood<br>([@rwood-97](https://github.com/rwood-97)) | The Alan Turing Institute | Research Data Scientist | Jan 2023 - Present | - |
-
-## Previous Project Members
-
-The following people are no longer paid to work on the project (although they remain very valuable members of the community!)
-You can request contact information through the project members above, or tag them in the GitHub issues and Pull Requests so others can answer if the folks you're looking for are not around.
-
-| Name | Affiliation | Community Role | Dates |
-|---|---|---|---|
-| Kasra Hosseini<br>([@kasra-hosseini](https://github.com/kasra-hosseini)) | Formerly The Alan Turing Institute | Research Data Scientist | 2019 - 2022 |
+# MapReader Ways of Working
 
 ## Commitments
 


### PR DESCRIPTION
### Summary

This PR splits the Code of conduct from the Contribution guide. 
See https://mapreader.readthedocs.io/en/rw_docs/index.html#

It also splits the Contributors from the Ways of working file.