### PR TITLE
Check both upper and lower corners when finding tilesize

### DIFF
--- a/mapreader/download/tile_merging.py
+++ b/mapreader/download/tile_merging.py
@@ -123,13 +123,15 @@ class TileMerger:
         tuple
             Size of tile
         """
-        for corner in [grid_bb.lower_corner, grid_bb.upper_corner]:
+        try:
+            start_image = self._load_image_to_grid_cell(grid_bb.lower_corner)
+        except FileNotFoundError:
+            logger.warning("Image has missing tiles in bottom left corner.")
             try:
-                start_image = self._load_image_to_grid_cell(corner)
-                break
-            except FileNotFoundError:
-                logger.warning("Image has missing tiles.")
-                continue
+                start_image = self._load_image_to_grid_cell(grid_bb.upper_corner)
+            except FileNotFoundError as err:
+                logger.warning("Image has missing tiles in upper right corner.")
+                raise FileNotFoundError("[ERROR] Image is missing tiles for both lower left and upper right corners.")
             
         img_size = start_image.size
         assert (

--- a/mapreader/download/tile_merging.py
+++ b/mapreader/download/tile_merging.py
@@ -123,7 +123,14 @@ class TileMerger:
         tuple
             Size of tile
         """
-        start_image = self._load_image_to_grid_cell(grid_bb.lower_corner)
+        for corner in [grid_bb.lower_corner, grid_bb.upper_corner]:
+            try:
+                start_image = self._load_image_to_grid_cell(corner)
+                break
+            except FileNotFoundError:
+                logger.warning("Image has missing tiles.")
+                continue
+            
         img_size = start_image.size
         assert (
             img_size[0] == img_size[1]
@@ -169,7 +176,7 @@ class TileMerger:
             try:
                 current_tile = Image.open(self._generate_tile_name(current_cell))
                 merged_image.paste(current_tile, (tile_size * i, tile_size * j))
-            except:
+            except FileNotFoundError:
                 logger.info(f"Cannot find tile with grid_index = {current_cell}")
 
         logger.info("Writing file..")


### PR DESCRIPTION
### Summary

At the moment to get the tile size, the tile merger looks at the size of the tile found in the bottom left corner of the image. This is problematic if this tile is missing.

This PR changes it so that it tries the lower left corner, then if its not found, tries the upper right corner and then if its not found, raises an error.

Addresses #239. 

### Checklist before assigning a reviewer (update as needed)
  
- [x] Self-review code
- [x] Ensure submission passes current tests
- [ ] Add tests
  
### Reviewer checklist
  
Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
