### PR TITLE
Ensure download doesn't fail if maps are not found

### DIFF
--- a/mapreader/download/tile_merging.py
+++ b/mapreader/download/tile_merging.py
@@ -159,7 +159,11 @@ class TileMerger:
         """
         os.makedirs(self.output_folder, exist_ok=True)
 
-        tile_size = self._load_tile_size(grid_bb)
+        try:
+            tile_size = self._load_tile_size(grid_bb)
+        except FileNotFoundError:
+            return False # unsuccessful
+
         merged_image = Image.new(
             "RGBA", (len(grid_bb.x_range) * tile_size, len(grid_bb.y_range) * tile_size)
         )


### PR DESCRIPTION
### Summary

In PR #269 I changed the code so that the downloader errored if both the bottom left and upper right corners of the map were missing.
This PR changes that so it so that if this error occurs, instead of erroring, MapReader prints a message saying that the download of xxx map was unsuccessful and then continues on to the next map.

Again, relates to #239 

### Checklist before assigning a reviewer (update as needed)
  
- [x] Self-review code
- [x] Ensure submission passes current tests
- [ ] Add tests
  
### Reviewer checklist
  
Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
