### PR TITLE
Update Annotate.rst

### DIFF
--- a/docs/source/User-guide/Annotate.rst
+++ b/docs/source/User-guide/Annotate.rst
@@ -1,6 +1,8 @@
 Annotate
 =========
 
+.. note:: Run these commands in a Jupyter notebook (or other IDE), ensuring you are in your `mapreader` python environment.
+
 .. note:: You will need to update file paths to reflect your own machine's directory structure.
 
 MapReader's ``Annotate`` subpackage is used to interactively annotate images (e.g. maps).


### PR DESCRIPTION
Add hint to the dependency on jupyter notebooks as annotation is done via ipyannotate (widget for jupyter)

### Summary

Added a hint to run annotation in jupyter-notebook. Preparation of custom map set worked up to this point outside 
jupyter. In the section annotate a user not aware of the jupyter requirement will be faced with an matplotlib window and 
no annotation widget interface.

Fixes #<NUM>

### Describe your changes
 

### Checklist before assigning a reviewer (update as needed)
  
- [ ] Self-review code
- [ ] Ensure submission passes current tests
- [ ] Add tests
  
### Reviewer checklist
  
Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
