### PR TITLE
Fix coordinate saving

### DIFF
--- a/mapreader/download/downloader_utils.py
+++ b/mapreader/download/downloader_utils.py
@@ -75,8 +75,8 @@ def get_grid_bb_from_polygon(polygon: Polygon, zoom_level: int):
     GridBoundingBox
     """
     min_x, min_y, max_x, max_y = polygon.bounds
-    start = Coordinate(min_y, max_x)  # (lat, lon)
-    end = Coordinate(max_y, min_x)  # (lat, lon)
+    start = Coordinate(min_y, min_x)  # (lat, lon), lower left
+    end = Coordinate(max_y, max_x)  # (lat, lon), upper right
     start_idx = get_index_from_coordinate(start, zoom_level)
     end_idx = get_index_from_coordinate(end, zoom_level)
     return GridBoundingBox(start_idx, end_idx)
@@ -94,9 +94,20 @@ def get_polygon_from_grid_bb(grid_bb: GridBoundingBox):
     -------
     shapely.Polygon
     """
-    lower_corner = get_coordinate_from_index(grid_bb.lower_corner)
-    upper_corner = get_coordinate_from_index(grid_bb.upper_corner)
-    polygon = create_polygon_from_latlons(lower_corner.lat, lower_corner.lon, upper_corner.lat, upper_corner.lon)
+    lower_corner = grid_bb.lower_corner # SW
+    upper_corner = grid_bb.upper_corner # SW
+
+    # for NE corner of upper right tile, do x+1 and y+1
+    upper_corner_NE = GridIndex(
+        upper_corner.x + 1, 
+        upper_corner.y + 1, 
+        upper_corner.z
+        )
+
+    SW_coord = get_coordinate_from_index(lower_corner) 
+    NE_coord = get_coordinate_from_index(upper_corner_NE)
+    
+    polygon = create_polygon_from_latlons(SW_coord.lat, SW_coord.lon, NE_coord.lat, NE_coord.lon)
     return polygon
 
 

--- a/mapreader/download/tile_merging.py
+++ b/mapreader/download/tile_merging.py
@@ -123,13 +123,15 @@ class TileMerger:
         tuple
             Size of tile
         """
-        for corner in [grid_bb.lower_corner, grid_bb.upper_corner]:
+        try:
+            start_image = self._load_image_to_grid_cell(grid_bb.lower_corner)
+        except FileNotFoundError:
+            logger.warning("Image has missing tiles in bottom left corner.")
             try:
-                start_image = self._load_image_to_grid_cell(corner)
-                break
-            except FileNotFoundError:
-                logger.warning("Image has missing tiles.")
-                continue
+                start_image = self._load_image_to_grid_cell(grid_bb.upper_corner)
+            except FileNotFoundError as err:
+                logger.warning("Image has missing tiles in upper right corner.")
+                raise FileNotFoundError("[ERROR] Image is missing tiles for both lower left and upper right corners.")
             
         img_size = start_image.size
         assert (


### PR DESCRIPTION
### Summary

This PR ensures that coordinates of the downloaded maps are saved correctly. 

![image](https://github.com/Living-with-machines/MapReader/assets/72076688/0ce4140b-e58d-485e-9dd1-0f38b13c2ae0)
When downloading tiles, the coordinates of the tile at (1,1) correspond to the bottom left corner of the tile. This is the same as the upper right corner of tile (0,0).

If tile (3,3) makes up the upper right corner of the map image we have downloaded, then the coordinate of the upper right corner of the map image is not the coordinate (3,3) but actually (4,4). 
This needed updating in the code as the coordinates that were previously saved were off by one tile index.

### Describe your changes
 Coordinates of NE corner of the map is now tile index +1 .

### Checklist before assigning a reviewer (update as needed)
  
- [x] Self-review code
- [x] Ensure submission passes current tests
- [ ] Add tests
  
### Reviewer checklist
  
Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
