### PR TITLE
Re-add `square_cuts` arg but with deprecation warning.

### DIFF
--- a/mapreader/load/images.py
+++ b/mapreader/load/images.py
@@ -37,6 +37,8 @@ import geopandas as geopd  # noqa: E402
 # Ignore warnings
 warnings.filterwarnings("ignore")
 
+Image.MAX_IMAGE_PIXELS = None  # suppress DecompressionBombError
+
 
 class MapImages:
     """

--- a/mapreader/load/images.py
+++ b/mapreader/load/images.py
@@ -1078,16 +1078,17 @@ See https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes for mor
                     verbose=verbose,
                 )
 
-            self._patchify_by_pixel(
-                image_id=image_id,
-                patch_size=patch_size,
-                path_save=path_save,
-                add_to_parents=add_to_parents,
-                resize_factor=resize_factor,
-                output_format=output_format,
-                rewrite=rewrite,
-                verbose=verbose,
-            )
+            else:
+                self._patchify_by_pixel(
+                    image_id=image_id,
+                    patch_size=patch_size,
+                    path_save=path_save,
+                    add_to_parents=add_to_parents,
+                    resize_factor=resize_factor,
+                    output_format=output_format,
+                    rewrite=rewrite,
+                    verbose=verbose,
+                )
 
     def _patchify_by_pixel(
         self,

--- a/mapreader/load/images.py
+++ b/mapreader/load/images.py
@@ -987,6 +987,7 @@ See https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes for mor
         tree_level: str | None = "parent",
         path_save: str | None = None,
         add_to_parents: bool | None = True,
+        square_cuts: bool | None = False,
         resize_factor: bool | None = False,
         output_format: str | None = "png",
         rewrite: bool | None = False,
@@ -1013,6 +1014,9 @@ See https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes for mor
         add_to_parents : bool, optional
             If True, patches will be added to the MapImages instance's
             ``images`` dictionary, by default ``True``.
+        square_cuts : bool, optional
+            If True, all patches will have the same number of pixels in
+            x and y, by default ``False``.
         resize_factor : bool, optional
             If True, resize the images before patchifying, by default ``False``.
         output_format : str, optional
@@ -1059,6 +1063,22 @@ See https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes for mor
                 patch_size = int(
                     original_patch_size / mean_pixel_height
                 )  ## check this is correct - should patch be different size in x and y?
+
+            if square_cuts:
+                print(
+                    "[WARNING] Square cuts is deprecated as of version 1.1.3 and will soon be removed."
+                )
+
+                self._patchify_by_pixel_square(
+                    image_id=image_id,
+                    patch_size=patch_size,
+                    path_save=path_save,
+                    add_to_parents=add_to_parents,
+                    resize_factor=resize_factor,
+                    output_format=output_format,
+                    rewrite=rewrite,
+                    verbose=verbose,
+                )
 
             self._patchify_by_pixel(
                 image_id=image_id,
@@ -1155,6 +1175,94 @@ See https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes for mor
                             f"[ERROR] Patch size is {patch.height}x{patch.width} instead of {patch_size}x{patch_size}."
                         )
 
+                    patch.save(patch_path, output_format)
+
+                if add_to_parents:
+                    self._images_constructor(
+                        image_path=patch_path,
+                        parent_path=parent_path,
+                        tree_level="patch",
+                        pixel_bounds=(min_x, min_y, max_x, max_y),
+                    )
+                    self._add_patch_coords_id(patch_id)
+                    self._add_patch_polygons_id(patch_id)
+
+    def _patchify_by_pixel_square(
+        self,
+        image_id: str,
+        patch_size: int,
+        path_save: str,
+        add_to_parents: bool | None = True,
+        resize_factor: bool | None = False,
+        output_format: str | None = "png",
+        rewrite: bool | None = False,
+        verbose: bool | None = False,
+    ):
+        """Patchify one image and (if ``add_to_parents=True``) add the patch to the MapImages instance's ``images`` dictionary.
+        Use square cuts for patches at edges.
+
+        Parameters
+        ----------
+        image_id : str
+            The ID of the image to patchify
+        patch_size : int
+            Number of pixels in both x and y to use for slicing
+        path_save : str
+            Directory to save the patches.
+        add_to_parents : bool, optional
+            If True, patches will be added to the MapImages instance's
+            ``images`` dictionary, by default ``True``.
+        resize_factor : bool, optional
+            If True, resize the images before patchifying, by default ``False``.
+        output_format : str, optional
+            Format to use when writing image files, by default ``"png"``.
+        rewrite : bool, optional
+            If True, existing patches will be rewritten, by default ``False``.
+        verbose : bool, optional
+            If True, progress updates will be printed throughout, by default
+            ``False``.
+        """
+        tree_level = self._get_tree_level(image_id)
+
+        parent_path = self.images[tree_level][image_id]["image_path"]
+        img = Image.open(parent_path)
+
+        if resize_factor:
+            original_height, original_width = img.height, img.width
+            img = img.resize(
+                (
+                    int(original_width / resize_factor),
+                    int(original_height / resize_factor),
+                )
+            )
+
+        height, width = img.height, img.width
+
+        for x in range(0, width, patch_size):
+            for y in range(0, height, patch_size):
+                max_x = min(x + patch_size, width)
+                max_y = min(y + patch_size, height)
+
+                # move min_x and min_y back a bit so the patch is square
+                min_x = x - (patch_size - (max_x - x))
+                min_y = y - (patch_size - (max_y - y))
+
+                patch_id = f"patch-{min_x}-{min_y}-{max_x}-{max_y}-#{image_id}#.{output_format}"
+                patch_path = os.path.join(path_save, patch_id)
+                patch_path = os.path.abspath(patch_path)
+
+                if os.path.isfile(patch_path) and not rewrite:
+                    self._print_if_verbose(
+                        f"[INFO] File already exists: {patch_path}.", verbose
+                    )
+
+                else:
+                    self._print_if_verbose(
+                        f'[INFO] Creating "{patch_id}". Number of pixels in x,y: {max_x - min_x},{max_y - min_y}.',
+                        verbose,
+                    )
+
+                    patch = img.crop((min_x, min_y, max_x, max_y))
                     patch.save(patch_path, output_format)
 
                 if add_to_parents:

--- a/mapreader/load/images.py
+++ b/mapreader/load/images.py
@@ -37,8 +37,6 @@ import geopandas as geopd  # noqa: E402
 # Ignore warnings
 warnings.filterwarnings("ignore")
 
-Image.MAX_IMAGE_PIXELS = None  # suppress DecompressionBombError
-
 
 class MapImages:
     """

--- a/tests/test_load/test_images.py
+++ b/tests/test_load/test_images.py
@@ -431,6 +431,18 @@ def test_patchify_pixels(sample_dir, image_id, tmp_path):
     assert os.path.isfile(f"{tmp_path}/patch-0-0-3-3-#{image_id}#.png")
 
 
+def test_patchify_pixels_square(sample_dir, image_id, tmp_path):
+    maps = MapImages(f"{sample_dir}/{image_id}")
+    maps.patchify_all(patch_size=5, path_save=f"{tmp_path}_square", square_cuts=True)
+    parent_list = maps.list_parents()
+    patch_list = maps.list_patches()
+    print(patch_list, flush=True)
+    assert len(parent_list) == 1
+    assert len(patch_list) == 4
+    assert os.path.isfile(f"{tmp_path}_square/patch-0-0-5-5-#{image_id}#.png")
+    assert os.path.isfile(f"{tmp_path}_square/patch-4-4-9-9-#{image_id}#.png")
+
+
 def test_patchify_meters(sample_dir, image_id, tmp_path):
     maps = MapImages(f"{sample_dir}/{image_id}")
     maps.add_metadata(f"{sample_dir}/ts_downloaded_maps.csv")


### PR DESCRIPTION
### Summary

In v1.1.3 I removed the `square_cuts` argument when patchifying images. 

In v1.1.2 or less, if you set `square_cuts=True`, when you reached an edge of an image, if your remaining 'slice' was less than the patch size you'd specified, you would move back a bit to create a square patch with some overlap with the previous patch. This essentially ensured all patches were square.
In v1.1.3+, I removed this in favour of padding the patches at edges. This still means you end up with square patches but if your 'slice' was less than the patch size you pad with x no. of pixels to create a square patch.

This PR re-adds the square-cuts argument to ensure bakcwards compatibility but with a deprecation warning.

### Describe your changes

Add `_patchify_by_pixel_square()` method for the square cuts. This is just copy-paste of previous code and gets called if you set `square_cuts=True`.

### Checklist before assigning a reviewer (update as needed)

- [x] Self-review code
- [x] Ensure submission passes current tests
- [x] Add tests
- [ ] Update relevant docs

### Reviewer checklist

Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
