### PR TITLE
Fix bug when reprojecting coordinates

### DIFF
--- a/mapreader/load/geo_utils.py
+++ b/mapreader/load/geo_utils.py
@@ -59,17 +59,15 @@ def reproject_geo_info(image_path, target_crs="EPSG:4326", calc_size_in_m=False)
     tiff_shape, tiff_proj, tiff_coord = extractGeoInfo(image_path)
 
     # Coordinate transformation: proj1 ---> proj2
-    transformer = Transformer.from_crs(tiff_proj, target_crs)
-    ymin, xmin = transformer.transform(tiff_coord[0], tiff_coord[1])
-    ymax, xmax = transformer.transform(tiff_coord[2], tiff_coord[3])
-    coord = (xmin, ymin, xmax, ymax)
-
+    transformer = Transformer.from_crs(tiff_proj, target_crs, always_xy=True)
+    coord = transformer.transform_bounds(*tiff_coord)
     print(f"[INFO] New CRS: {target_crs}")
     print("[INFO] Reprojected coordinates: {:.4f} {:.4f} {:.4f} {:.4f}".format(*coord))
 
     height, width, _ = tiff_shape
 
     # Calculate the size of image in meters
+    xmin, ymin, xmax, ymax = coord
     if calc_size_in_m:
         if calc_size_in_m in ["geodesic", "gd"]:
             bottom = geodesic((ymin, xmin), (ymin, xmax)).meters

--- a/mapreader/load/images.py
+++ b/mapreader/load/images.py
@@ -2108,15 +2108,8 @@ See https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes for mor
             tiff_proj = tiff_src.crs.to_string()
             # Coordinate transformation: proj1 ---> proj2
             # tiff is "lat, lon" instead of "x, y"
-            transformer = Transformer.from_crs(tiff_proj, target_crs)
-            ymin, xmin = transformer.transform(
-                tiff_src.bounds.left, tiff_src.bounds.bottom
-            )
-            ymax, xmax = transformer.transform(
-                tiff_src.bounds.right, tiff_src.bounds.top
-            )
-            # New projected coordinates
-            coords = (xmin, ymin, xmax, ymax)
+            transformer = Transformer.from_crs(tiff_proj, target_crs, always_xy=True)
+            coords = transformer.transform_bounds(*tiff_src.bounds)
             self.parents[image_id]["coordinates"] = coords
             self.parents[image_id]["crs"] = target_crs
 

--- a/tests/test_load/test_geo_utils.py
+++ b/tests/test_load/test_geo_utils.py
@@ -38,7 +38,7 @@ def test_reproject(sample_dir):
     assert new_crs == "EPSG:4326"
     assert reprojected_coord == approx((-0.061, 51.6142, -0.0610, 51.614), rel=1e-2)
     print(size_in_m)
-    assert size_in_m == approx((0.5904, 0.6209, 0.594, 0.6209), rel=1e-2)
+    assert size_in_m == approx((0.62, 0.62, 0.62, 0.62), rel=1e-2)
 
 
 def test_versus_loader(sample_dir):


### PR DESCRIPTION
### Summary

Thanks to @DGalexander for flagging this.

This PR fixes mapreader's reproject coords functions when converting between coordinate systems.

### Describe your changes

- coords are transformed from bounds:  (left, bottom, right, top) == (xmin, ymin, xmax, ymax)
- always_xy is set to True to ensure no variation between crs ordering

### Checklist before assigning a reviewer (update as needed)

- [x] Self-review code
- [x] Ensure submission passes current tests

### Reviewer checklist

Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
