### PR TITLE
Update saving for duplicate sheet names with different coords

### DIFF
--- a/mapreader/download/tile_merging.py
+++ b/mapreader/download/tile_merging.py
@@ -142,7 +142,12 @@ class TileMerger:
         tile_size = img_size[0]
         return tile_size
 
-    def merge(self, grid_bb: GridBoundingBox, file_name: str | None = None) -> bool:
+    def merge(
+        self,
+        grid_bb: GridBoundingBox,
+        file_name: str | None = None,
+        overwrite: bool = False,
+    ) -> str | bool:
         """Merges cells contained within GridBoundingBox.
 
         Parameters
@@ -151,11 +156,13 @@ class TileMerger:
             GridBoundingBox containing tiles to merge
         file_name : Union[str, None], optional
             Name to use when saving map
-
+            If None, default name will be used, by default None
+        overwrite : bool, optional
+            Whether or not to overwrite existing files, by default False
         Returns
         -------
-        bool
-            True if file has successfully downloaded, False if not.
+        str or bool
+            out path if file has successfully downloaded, False if not.
         """
         os.makedirs(self.output_folder, exist_ok=True)
 
@@ -191,12 +198,13 @@ class TileMerger:
             file_name = self._get_output_name(grid_bb)
 
         out_path = f"{self.output_folder}{file_name}.{self.img_output_format[0]}"
-        i = 1
-        while os.path.exists(out_path):
-            out_path = (
-                f"{self.output_folder}{file_name}_{i}.{self.img_output_format[0]}"
-            )
-            i += 1
+        if not overwrite:
+            i = 1
+            while os.path.exists(out_path):
+                out_path = (
+                    f"{self.output_folder}{file_name}_{i}.{self.img_output_format[0]}"
+                )
+                i += 1
         merged_image.save(out_path, self.img_output_format[1])
         success = out_path if os.path.exists(out_path) else False
         if success is False:

--- a/mapreader/download/tile_merging.py
+++ b/mapreader/download/tile_merging.py
@@ -191,11 +191,17 @@ class TileMerger:
             file_name = self._get_output_name(grid_bb)
 
         out_path = f"{self.output_folder}{file_name}.{self.img_output_format[0]}"
+        i = 1
+        while os.path.exists(out_path):
+            out_path = (
+                f"{self.output_folder}{file_name}_{i}.{self.img_output_format[0]}"
+            )
+            i += 1
         merged_image.save(out_path, self.img_output_format[1])
-        success = True if os.path.exists(out_path) else False
-        if success:
-            logger.info(f"Merge successful! The image has been stored at '{out_path}'")
-        else:
+        success = out_path if os.path.exists(out_path) else False
+        if success is False:
             logger.warning(f"Merge unsuccessful! '{out_path}' not saved.")
+        else:
+            logger.info(f"Merge successful! The image has been stored at '{out_path}'")
 
         return success

--- a/tests/sample_files/test_json.json
+++ b/tests/sample_files/test_json.json
@@ -1,6 +1,6 @@
 {
     "type": "FeatureCollection",
-    "totalFeatures": 4,
+    "totalFeatures": 6,
     "features": [
         {
             "type": "Feature",
@@ -217,6 +217,194 @@
                 "WFS_TITLE": "London VI.SE, Revised: 1893 to 1894, Published: 1894 to 1896",
                 "test": "test"
             }
+        },
+        {
+            "type": "Feature",
+            "id": "Six_Inch_GB_WFS.107",
+            "test_date": "2021",
+            "geometry": {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [
+                        [
+                            [
+                                -4.7674,
+                                53.2872
+                            ],
+                            [
+                                -4.7682,
+                                53.3161
+                            ],
+                            [
+                                -4.6957,
+                                53.3168
+                            ],
+                            [
+                                -4.695,
+                                53.2879
+                            ],
+                            [
+                                -4.7674,
+                                53.2872
+                            ]
+                        ]
+                    ]
+                ]
+            },
+            "geometry_name": "the_geom",
+            "properties": {
+                "IMAGE": "101603986",
+                "SERIES": "OS 6 Inch to the Mile - England & Wales",
+                "SET": "6Q_A",
+                "COUNTRY": "WAL",
+                "COUNTY": "Anglesey",
+                "SHEET_MAP": "X.NE & XI.NW",
+                "SHEET_NO": "010_NE",
+                "EDITION": "2",
+                "INSET_EXT": "",
+                "RESURVEY": "",
+                "SUR_STA": "1899",
+                "SUR_END": "1899",
+                "PSUR_STA": "",
+                "PSUR_END": "",
+                "ENG_STA": "",
+                "ENG_END": "",
+                "REV_STA": "",
+                "REV_END": "",
+                "PUB_STA": "1901",
+                "PUB_END": "1901",
+                "PPUB_STA": "",
+                "PPUB_END": "",
+                "PRI_STA": "",
+                "PRI_END": "",
+                "RPRI_STA": "",
+                "RPRI_END": "",
+                "MSD_SIG": "",
+                "LEV_STA": "",
+                "LEV_END": "",
+                "BOUND_STA": "",
+                "BOUND_END": "",
+                "SUR_SORT": "1899",
+                "PUB_SORT": "1901",
+                "PARISH": "Holyhead Rural; Holyhead Urban",
+                "RAILWAYS": "",
+                "RECORDSET": "",
+                "BNDRY_INST": "",
+                "YEAR": "1901",
+                "GROUP": "102",
+                "IN_NLS": "Y",
+                "NOTE_MAP": "",
+                "NOTE_LIST": "",
+                "SHEET": "Anglesey X.NE & XI.NW",
+                "DATES": "Series: Ordnance Survey. Six-inch to the mile<br>Revised: 1899<br>Published: 1901",
+                "IMAGETHUMB": "https://deriv.nls.uk/dcn4/1016/0398/101603986.4.jpg",
+                "IMAGEURL": "https://maps.nls.uk/view/101603986",
+                "IIIF_JSON": "https://map-view.nls.uk/iiif/2/10160%2F101603986/info.json",
+                "WFS_TITLE": "Anglesey X.NE & XI.NW, Revised: 1899, Published: 1901",
+                "WFS": "Y",
+                "OR_Num": "0",
+                "test": "test"
+            },
+            "bbox": [
+                -4.7682,
+                53.2872,
+                -4.695,
+                53.3168
+            ]
+        },
+        {
+            "type": "Feature",
+            "id": "Six_Inch_GB_WFS.116",
+            "test_date": "2021",
+            "geometry": {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [
+                        [
+                            [
+                                -4.695,
+                                53.2879
+                            ],
+                            [
+                                -4.6957,
+                                53.3168
+                            ],
+                            [
+                                -4.6233,
+                                53.3175
+                            ],
+                            [
+                                -4.6226,
+                                53.2885
+                            ],
+                            [
+                                -4.695,
+                                53.2879
+                            ]
+                        ]
+                    ]
+                ]
+            },
+            "geometry_name": "the_geom",
+            "properties": {
+                "IMAGE": "101603986",
+                "SERIES": "OS 6 Inch to the Mile - England & Wales",
+                "SET": "6Q_A",
+                "COUNTRY": "WAL",
+                "COUNTY": "Anglesey",
+                "SHEET_MAP": "X.NE & XI.NW",
+                "SHEET_NO": "011_NW",
+                "EDITION": "2",
+                "INSET_EXT": "",
+                "RESURVEY": "",
+                "SUR_STA": "1899",
+                "SUR_END": "1899",
+                "PSUR_STA": "",
+                "PSUR_END": "",
+                "ENG_STA": "",
+                "ENG_END": "",
+                "REV_STA": "",
+                "REV_END": "",
+                "PUB_STA": "1901",
+                "PUB_END": "1901",
+                "PPUB_STA": "",
+                "PPUB_END": "",
+                "PRI_STA": "",
+                "PRI_END": "",
+                "RPRI_STA": "",
+                "RPRI_END": "",
+                "MSD_SIG": "",
+                "LEV_STA": "",
+                "LEV_END": "",
+                "BOUND_STA": "",
+                "BOUND_END": "",
+                "SUR_SORT": "1899",
+                "PUB_SORT": "1901",
+                "PARISH": "Holyhead Rural; Holyhead Urban",
+                "RAILWAYS": "",
+                "RECORDSET": "",
+                "BNDRY_INST": "",
+                "YEAR": "1901",
+                "GROUP": "102",
+                "IN_NLS": "Y",
+                "NOTE_MAP": "",
+                "NOTE_LIST": "",
+                "SHEET": "Anglesey X.NE & XI.NW",
+                "DATES": "Series: Ordnance Survey. Six-inch to the mile<br>Revised: 1899<br>Published: 1901",
+                "IMAGETHUMB": "https://deriv.nls.uk/dcn4/1016/0398/101603986.4.jpg",
+                "IMAGEURL": "https://maps.nls.uk/view/101603986",
+                "IIIF_JSON": "https://map-view.nls.uk/iiif/2/10160%2F101603986/info.json",
+                "WFS_TITLE": "Anglesey X.NE & XI.NW, Revised: 1899, Published: 1901",
+                "WFS": "Y",
+                "OR_Num": "0",
+                "test": "test"
+            },
+            "bbox": [
+                -4.6957,
+                53.2879,
+                -4.6226,
+                53.3175
+            ]
         }
     ],
     "crs": {

--- a/tests/test_sheet_downloader.py
+++ b/tests/test_sheet_downloader.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import re
 from ast import literal_eval
 from pathlib import Path
 
@@ -504,11 +503,6 @@ def test_download_same_image_names(sheet_downloader, tmp_path, capfd):
     sd.download_map_sheets_by_wfs_ids(
         [107, 116], maps_path, metadata_fname, overwrite=True
     )  # 107 and 116 both refer to https://maps.nls.uk/view/101603986
-    out, _ = capfd.readouterr()
-    assert re.search(
-        r"\[INFO\] Downloaded \".*\/test_maps\/map_101603986.png\"\n\[INFO\] Downloaded \".*\/test_maps\/map_101603986_1.png\"\n$",
-        out,
-    )
     assert os.path.exists(f"{maps_path}/map_101603986.png")
     assert os.path.exists(f"{maps_path}/map_101603986_1.png")
     assert os.path.exists(f"{maps_path}/{metadata_fname}")


### PR DESCRIPTION
### Summary

Fixes #398 

### Describe your changes

e.g. https://maps.nls.uk/view/101437802 goes over the boundary and so is registered twice in the NLS metadata but with two sets of coordinates. 
Instead of erroring or overwriting the sheet, you will now get map_xxxx.png and map_xxxx_1.png saved and these will have separate metadata so separate coordinates.

This also adds a mock function when downloading maps and so fixes #183 

### Checklist before assigning a reviewer (update as needed)

- [x] Self-review code
- [x] Ensure submission passes current tests
- [x] Add tests

### Reviewer checklist

Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
