### PR TITLE
Fix review_labels 

### DIFF
--- a/mapreader/classify/load_annotations.py
+++ b/mapreader/classify/load_annotations.py
@@ -395,7 +395,9 @@ Please check your image paths and update them if necessary.'
                 )
                 iter_ids.append(annots2review.iloc[image_idx].name)
                 # Add to reviewed
-                self.reviewed = self.reviewed.append(annots2review.iloc[image_idx])
+                self.reviewed = pd.concat(
+                    [self.reviewed, annots2review.iloc[image_idx : image_idx + 1]]
+                )
                 try:
                     self.reviewed.drop_duplicates(subset=[deduplicate_col])
                 except Exception:
@@ -416,9 +418,14 @@ Please check your image paths and update them if necessary.'
             ]:
                 list_input_ids = user_input_ids.split(",")
                 print(
-                    f"[INFO] Options for labels (or create a new label):{list(self.annotations[self.label_col].unique())}"
+                    f"[INFO] Options for labels:{list(self.annotations[self.label_col].unique())}"
                 )
                 input_label = input("Enter new label:  ")
+                if input_label not in list(self.annotations[self.label_col].unique()):
+                    print(
+                        f'[ERROR] Label "{input_label}" not found in the annotations. Please enter a valid label.'
+                    )
+                    continue
 
                 for input_id in list_input_ids:
                     input_id = int(input_id)


### PR DESCRIPTION
### Summary

Fixes #400 

### Describe your changes

Previous code allowed you enter a new label when reviewing labels but would give you an error (even though it relabelled the patch fine). Now we give an error and only allow user to enter one of the existing labels when re-labelling/reviewing their annotations.

### Checklist before assigning a reviewer (update as needed)

- [x] Self-review code
- [x] Ensure submission passes current tests
- [ ] Add tests
- [ ] Update relevant docs

### Reviewer checklist

Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
