### PR TITLE
Add pre-commit to documentation

### DIFF
--- a/docs/source/Developers-guide.rst
+++ b/docs/source/Developers-guide.rst
@@ -1,6 +1,18 @@
 Developer's Guide
 =================
 
+Installing and using pre-commit
+--------------------------------
+
+MapReader uses `pre-commit <https://pre-commit.com/>`_ to enforce code style and quality.  To install pre-commit, run the following commands:
+
+.. code-block:: bash
+
+  pip install pre-commit
+  pre-commit install
+
+This will install the pre-commit hooks in the repository.  The hooks will run automatically when you commit code.  If the hooks fail, the commit will be aborted.
+
 Managing version numbers
 ------------------------
 


### PR DESCRIPTION
Fixes #453

### Summary

Adds in the pre-commit information in the developer documentation for MapReader.

Fixes #453

### Describe your changes

- [ ] Added a block with `pre-commit` install and use information in the "developer's corner" of the documentation

### Reviewer checklist

Please add anything you want reviewers to specifically focus/comment on.

- [ ] Everything looks ok?
